### PR TITLE
add-bundle.sh: name the catalog directory after the bundle's package

### DIFF
--- a/hack/add-bundle.sh
+++ b/hack/add-bundle.sh
@@ -30,15 +30,18 @@ echo "Found CSV file: $CSV_FILE"
 # Extract the name from the CSV file
 NAME=$(yq e '.metadata.name' $CSV_FILE)
 
-# Split the name by the first period
-IFS='.' read -r OPERATOR_NAME CSV_VERSION <<< "$NAME"
-VERSION=${CSV_VERSION#v}
+# Render the bundle; its package field names the catalog directory (the
+# CSV name prefix is not a reliable package name, e.g. the CSV
+# clusterkubedescheduleroperator.vX belongs to the package
+# cluster-kube-descheduler-operator)
+RENDERED=$(opm render $BUNDLE -o yaml)
+PACKAGE_NAME=$(echo "$RENDERED" | yq e 'select(.schema == "olm.bundle") | .package' -)
 
 # Create the operator catalog directory
-mkdir -p catalog/$OPERATOR_NAME
+mkdir -p catalog/$PACKAGE_NAME
 
-# Render the bundle to a new file in the operator catalog directory
-opm render $BUNDLE -o yaml > catalog/$OPERATOR_NAME/$NAME.yaml
+# Write the rendered bundle to a new file in the operator catalog directory
+echo "$RENDERED" > catalog/$PACKAGE_NAME/$NAME.yaml
 
 # Delete the temporary directory
 rm -rf $TEMP_DIR


### PR DESCRIPTION
`hack/add-bundle.sh` derives the catalog directory from the CSV name prefix, which is not a reliable package name — kube-descheduler's CSV is `clusterkubedescheduleroperator.vX` while its package is `cluster-kube-descheduler-operator`, which is how #49 ended up with the bundle file and the package file in two different directories. `cluster-logging` has the same CSV/package mismatch and was evidently placed under `catalog/cluster-logging` by hand.

This renders the bundle once and takes the directory name from the rendered bundle's `package` field, matching okd-project/okd-operator-pipeline#27, which made the same change to the catalog-pr workflow's package-file derivation.

No existing directories need renaming: every current catalog directory already matches its `olm.package` name, so this only affects where future bundles land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)