### PR TITLE
add-bundle.sh: name the catalog directory after the bundle's package (release-4.20)

### DIFF
--- a/hack/add-bundle.sh
+++ b/hack/add-bundle.sh
@@ -30,15 +30,18 @@ echo "Found CSV file: $CSV_FILE"
 # Extract the name from the CSV file
 NAME=$(yq e '.metadata.name' $CSV_FILE)
 
-# Split the name by the first period
-IFS='.' read -r OPERATOR_NAME CSV_VERSION <<< "$NAME"
-VERSION=${CSV_VERSION#v}
+# Render the bundle; its package field names the catalog directory (the
+# CSV name prefix is not a reliable package name, e.g. the CSV
+# clusterkubedescheduleroperator.vX belongs to the package
+# cluster-kube-descheduler-operator)
+RENDERED=$(opm render $BUNDLE -o yaml)
+PACKAGE_NAME=$(echo "$RENDERED" | yq e 'select(.schema == "olm.bundle") | .package' -)
 
 # Create the operator catalog directory
-mkdir -p catalog/$OPERATOR_NAME
+mkdir -p catalog/$PACKAGE_NAME
 
-# Render the bundle to a new file in the operator catalog directory
-opm render $BUNDLE -o yaml > catalog/$OPERATOR_NAME/$NAME.yaml
+# Write the rendered bundle to a new file in the operator catalog directory
+echo "$RENDERED" > catalog/$PACKAGE_NAME/$NAME.yaml
 
 # Delete the temporary directory
 rm -rf $TEMP_DIR


### PR DESCRIPTION
release-4.20 counterpart of #50 — the catalog-pr workflow in okd-operator-pipeline checks out whichever branch it targets and runs that branch's `hack/add-bundle.sh`, so a run with `catalog_branch: release-4.20` needs the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)