### PR TITLE
Deploy catalog on pushes to release branches

### DIFF
--- a/.github/workflows/deploy-catalog.yml
+++ b/.github/workflows/deploy-catalog.yml
@@ -1,10 +1,10 @@
 name: Deploy Production Catalog
 
-on: 
+on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - 'release-*'
 
 jobs:
   build-deploy:
@@ -13,6 +13,16 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+      - name: Derive catalog tag from branch name
+        id: catalog-tag
+        # release-4.21 -> 4.21; guards workflow_dispatch runs started
+        # from a branch that does not deploy to a versioned tag
+        run: |
+          if [[ "$GITHUB_REF_NAME" != release-* ]]; then
+            echo "Branch '$GITHUB_REF_NAME' is not a release branch; refusing to deploy." >&2
+            exit 1
+          fi
+          echo "tag=${GITHUB_REF_NAME#release-}" >> "$GITHUB_OUTPUT"
       - name: Prepare image tags and labels
         id: image-meta-gen
         uses: docker/metadata-action@v5
@@ -20,7 +30,7 @@ jobs:
           images: |
             quay.io/okderators/catalog-index
           tags: |
-            type=raw,value=latest
+            type=raw,value=${{ steps.catalog-tag.outputs.tag }}
       - name: Build Catalog Image
         id: build-catalog-image
         uses: redhat-actions/buildah-build@v2


### PR DESCRIPTION
## Problem

The deploy workflow only triggers on pushes to `main` and always pushes the `latest` tag, but releases now live on `release-*` branches and clusters consume versioned tags (`:4.21`, `:4.20`, ...). As a result, merges to `release-4.21` deploy nothing — the `4.21` image on quay.io currently lags the branch by several weeks and versioned pushes have to be done by hand. Additionally, manually dispatching the workflow from a release branch would build that branch's catalog but push it over `latest`, which is the tag consumed by 4.15 clusters.

## Changes

- Trigger the workflow on pushes to `release-*` branches instead of `main`.
- Derive the image tag from the branch name (`release-4.21` → `4.21`); the workflow no longer touches `latest` at all.
- Fail fast if the workflow is dispatched from a branch that isn't a release branch, before anything is built or pushed.

Since push-triggered workflows run from the pushed branch's own copy of the file, this change needs to be cherry-picked to any other release branch that should auto-deploy (e.g. `release-4.20`). The file is branch-agnostic, so the same commit applies cleanly everywhere.