### PR TITLE
Deploy catalog on pushes to release branches (release-4.20)

### DIFF
--- a/.github/workflows/deploy-catalog.yml
+++ b/.github/workflows/deploy-catalog.yml
@@ -1,10 +1,10 @@
 name: Deploy Production Catalog
 
-on: 
+on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - 'release-*'
 
 jobs:
   build-deploy:
@@ -13,6 +13,16 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+      - name: Derive catalog tag from branch name
+        id: catalog-tag
+        # release-4.21 -> 4.21; guards workflow_dispatch runs started
+        # from a branch that does not deploy to a versioned tag
+        run: |
+          if [[ "$GITHUB_REF_NAME" != release-* ]]; then
+            echo "Branch '$GITHUB_REF_NAME' is not a release branch; refusing to deploy." >&2
+            exit 1
+          fi
+          echo "tag=${GITHUB_REF_NAME#release-}" >> "$GITHUB_OUTPUT"
       - name: Prepare image tags and labels
         id: image-meta-gen
         uses: docker/metadata-action@v5
@@ -20,7 +30,7 @@ jobs:
           images: |
             quay.io/okderators/catalog-index
           tags: |
-            type=raw,value=latest
+            type=raw,value=${{ steps.catalog-tag.outputs.tag }}
       - name: Build Catalog Image
         id: build-catalog-image
         uses: redhat-actions/buildah-build@v2


### PR DESCRIPTION
Cherry-pick of #56 onto `release-4.20`.

Push-triggered workflows run from the pushed branch's own copy of the workflow file, so `release-4.20` needs this change too for merges to auto-deploy the `:4.20` tag. Same commit as #56: trigger on `release-*` branches, derive the image tag from the branch name (`release-4.20` → `4.20`), never touch `latest`, and fail fast when dispatched from a non-release branch.